### PR TITLE
Surface Signup Errors

### DIFF
--- a/source/assets/javascripts/_signup_embed/setup.js.erb
+++ b/source/assets/javascripts/_signup_embed/setup.js.erb
@@ -54,7 +54,7 @@ if(options.websiteInput) {
   signupFormTemplate += '<div class="form-group">' +
       '<label class="col-sm-4 control-label" for="user_website">Website<br />(optional)</label>' +
       '<div class="col-sm-5">' +
-        '<input class="form-control" id="user_website" name="user[website]" size="50" type="text" placeholder="http://" />' +
+        '<input class="form-control" id="user_website" name="user[website]" size="50" type="url" placeholder="http://" />' +
       '</div>' +
     '</div>';
 }

--- a/source/assets/javascripts/_signup_embed/setup.js.erb
+++ b/source/assets/javascripts/_signup_embed/setup.js.erb
@@ -131,11 +131,24 @@ form.submit(function(event) {
     $(options.containerSelector).html(confirmationTemplate);
     $(options.containerSelector)[0].scrollIntoView();
   }).fail(function(xhr, message, error) {
+    var messages = [],
+        messageStr = '';
     if(typeof(Rollbar) != 'undefined') {
       Rollbar.error('Unexpected signup failure', { error: error, message: message, response: xhr.responseText  });
     }
 
-    bootbox.alert('API key signup unexpectedly failed.<br>Please try again or <a href="' + options.contactUrl + '">contact us</a> for assistance.');
+    if (xhr.responseJSON && xhr.responseJSON.errors) {
+      $.each(xhr.responseJSON.errors, function(idx, error) {
+        if (error.message) {
+          messages.push(error.message);
+        }
+      });
+    }
+    if (messages) {
+      messageStr = '<br><ul><li>' + messages.join('</li><li>') + '</li></ul>';
+    }
+
+    bootbox.alert('API key signup unexpectedly failed.' + messageStr + '<br>Please try again or <a href="' + options.contactUrl + '">contact us</a> for assistance.');
   }).always(function() {
     submit.button('reset');
   });


### PR DESCRIPTION
For https://github.com/18F/api.data.gov/issues/236 . This relays any specific error messages during sign up to the user. E.g.
![screen shot 2015-06-05 at 12 17 55 pm](https://cloud.githubusercontent.com/assets/326918/8011472/92d8b8ac-0b7e-11e5-896f-ef4edd12248c.png)

It also resolves the specific error by giving an in-line error message via the Parsley library's url [validator](http://parsleyjs.org/doc/index.html#psly-validators-list). Looks like:
![screen shot 2015-06-05 at 12 27 48 pm](https://cloud.githubusercontent.com/assets/326918/8011501/cef97fc4-0b7e-11e5-95ea-8ec18bf6a9c1.png)

Url remains optional.